### PR TITLE
Some suggested changes to the readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,14 +7,11 @@ This project is up for adoption.
 KCMO runs monthly auctions of cars and other items (boats,
 scooters, etc) that are unclaimed from city tow lots, but
 information about the items up for auction isn’t easily accessible
-by the salvage dealers.
+by salvage dealers. A list of the vehicles up for auction is available online that includes limited information about the condition of the vehicles. The minimal user interface fosters a limited market of buyers, reducing revenue and resulting in fewer vehicles being sold. 
 
-There
-are current auction attendees who know how to work the system,
-and most of the items for auction are purchase, but we believe there
-may be an opportunity to increase revenue, reduce waste (into the
+There is an opportunity to increase revenue, increase sales, reduce waste (into the
 landfill), or even connect more people to low cost vehicles with
-greater accessibility and transparency to the data.
+better access to more, relevant data.
 
 ## What we need
 
@@ -47,7 +44,10 @@ and how to download it or ascdess it using a RESTful API (JSON).  It also contai
 ## Possible steps:
 
 * Review the existing data source
+* Interview Tow Services Section Section Staff and identify an agency project champion
+* Conduct user interviews with salvage dealers that do and do not participate in the auctions
 * Design a system
+* Wireframe a user interface
 * Create a road map and issues that can be followed to implement
 * Implement
 


### PR DESCRIPTION
A few suggestions were provided to simplify the explanation. 

The idea of having an MVP and identifying possible future opportunities is good. It took me a little bit to realize it, but the graphs in the existing website provide a quick one- or two-dimensional filter. The list provides a quick way by which to sort each field. So the only sure "refinements" to the website is to show the time and date of the upcoming auction (and to have a clearer interface with more options for a combination search and filter.) One step in the process should probably be a customer survey of salvage dealers who do not participate in the auction. What would they need to know to be motivated to attend the auctions. 

The other thing I would identify is that the "Auction Rules and Regulations" are a little confusing in terms of whether a non-salvage dealer (like a regular citizen) can participate in the auction (in other words, are all cars "salvage" or only those that are damaged?). The language is pretty standard government legalese, but it could benefit from a rewrite. As part of the quid pro quo for Code for America doing this job, there needs to be a person from the unclaimed auction people who will have the authority to help clarify or simplify the rules (even if just a little) and to create a path for adding additional information in the future (such as pictures, or an identification of the panels damaged, etc.). This project needs to have a path to 2.0 to make it worth the while of a team working on it. 
Scott